### PR TITLE
DomBuilder.close() returns the created Element in browser implementat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ doc/api/
 *.iml
 .idea
 
+# macOS
+.DS_Store
+
 #
 .local-chromium

--- a/domino/CHANGELOG.md
+++ b/domino/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.2
+
+- For browser implementation of `DomBuilder`, the`close()` method now returns the created `Element`.
+
 ## 0.8.1
 
 - `onUpdate` callback similar to `onCreate`.

--- a/domino/example/example.dart
+++ b/domino/example/example.dart
@@ -3,26 +3,28 @@ import 'dart:html';
 import 'package:domino/browser.dart';
 
 void main() {
-  registerView(root: document.getElementById('root')!, builderFn: _app);
+  registerView(root: document.getElementById('root')!, builderFn: _App().build);
 }
 
-int _counter = 0;
+class _App {
+  int _counter = 0;
 
-void _app(DomBuilder<Element, Event> b) {
-  b.open(
-    'button',
-    id: 'app-button',
-    events: {
-      'click': (e) {
-        _counter++;
-        e.view.invalidate();
+  void build(DomBuilder<Element, Event> b) {
+    b.open(
+      'button',
+      id: 'app-button',
+      events: {
+        'click': (e) {
+          _counter++;
+          e.view.invalidate();
+        },
       },
-    },
-  );
-  b.text('Click');
-  b.close();
+    );
+    b.text('Click');
+    b.close();
 
-  b.open('div', id: 'app-count');
-  b.text('Counter: $_counter');
-  b.close();
+    b.open('div', id: 'app-count');
+    b.text('Counter: $_counter');
+    b.close();
+  }
 }

--- a/domino/example/example.dart
+++ b/domino/example/example.dart
@@ -3,26 +3,26 @@ import 'dart:html';
 import 'package:domino/browser.dart';
 
 void main() {
-  window.onLoad.listen((_) => _main());
+  registerView(root: document.getElementById('root')!, builderFn: _app);
 }
 
-void _main() {
-  registerView(root: document.getElementById('root')!, builderFn: _App().build);
-}
+int _counter = 0;
 
-class _App extends DomNode {
-  int _counter = 0;
+void _app(DomBuilder<Element, Event> b) {
+  b.open(
+    'button',
+    id: 'app-button',
+    events: {
+      'click': (e) {
+        _counter++;
+        e.view.invalidate();
+      },
+    },
+  );
+  b.text('Click');
+  b.close();
 
-  @override
-  void build(DomBuilder b) {
-    b.visitAll([
-      DomElement('button', id: 'app-button', events: {
-        'click': (e) {
-          _counter++;
-          e.view.invalidate();
-        },
-      }),
-      DomElement('span', id: 'app-count', text: 'Counter: $_counter'),
-    ]);
-  }
+  b.open('div', id: 'app-count');
+  b.text('Counter: $_counter');
+  b.close();
 }

--- a/domino/example/index.html
+++ b/domino/example/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>domino example</title>
+    <script defer src="example.dart.js"></script>
+</head>
+
+<body>
+    <div id="root"></div>
+</body>
+
+</html>

--- a/domino/lib/src/dom_builder.dart
+++ b/domino/lib/src/dom_builder.dart
@@ -27,7 +27,7 @@ abstract class DomBuilder<L, V> {
   void skipRemainingNodes();
 
   /// Close the current element.
-  void close({String? tag});
+  L close({String? tag});
 
   /// Calls [DomNode.build] with the current [DomBuilder] on [node].
   void visit(DomNode node) => node.build(this);
@@ -49,7 +49,7 @@ typedef DomLifecycleEventFn<L> = Function(DomLifecycleEvent<L> event);
 typedef DomEventFn<L, V> = Function(DomEvent<L, V> event);
 
 /// DOM builder function.
-typedef DomBuilderFn = void Function(DomBuilder b);
+typedef DomBuilderFn<L, V> = void Function(DomBuilder<L, V> b);
 
 /// Provides lifecycle handling for a hierarchy of components.
 /// A [DomView] re-builds the UI after `invalidate()` is called.

--- a/domino/pubspec.yaml
+++ b/domino/pubspec.yaml
@@ -13,4 +13,6 @@ dev_dependencies:
   puppeteer: ^2.5.0
   shelf: ^1.2.0
   shelf_static: ^1.1.0
-  test: ^1.3.0
+  test: ^1.20.1
+  build_runner: ^2.1.7
+  build_web_compilers: ^3.2.2

--- a/domino/pubspec.yaml
+++ b/domino/pubspec.yaml
@@ -1,6 +1,6 @@
 name: domino
 description: An incremental DOM library, with support for virtual DOM and components.
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/agilord/domino/tree/main/domino
 
 environment:


### PR DESCRIPTION
resolves #4

What I have done:
- `DomBuilder.close()` returns the created `Element` in the browser implementation
- Updated example and make it runnable using `webdev serve example:8000`.
- Added macOS specific files to `.gitignore`.
- Updated `test` dependency to newest version to run tests on macOS.

I like to write a test for this. But I have no idea how to integrate it with the current test structure. Any idea?